### PR TITLE
geet init 명령어를 처리하는 feat/init 브랜치 메인 브랜치로 병합

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,6 +1,7 @@
+import geet.processGeet
 import parser.parseCommandLine
 
 fun main(args: Array<String>) {
     val parseData = parseCommandLine(args)
-    println(parseData)
+    processGeet(parseData)
 }

--- a/src/main/kotlin/geet/ProcessGeet.kt
+++ b/src/main/kotlin/geet/ProcessGeet.kt
@@ -4,7 +4,7 @@ fun processGeet(parseData: Map<String, String>): Unit {
     when (parseData["command"]) {
         "init" -> println("init")
         null -> guideGeet()
-        else -> println("geet ${parseData["command"]} is not a valid command. Try init instead.")
+        else -> println("'geet ${parseData["command"]}'은 지원하는 명령어가 아닙니다.")
     }
 }
 

--- a/src/main/kotlin/geet/ProcessGeet.kt
+++ b/src/main/kotlin/geet/ProcessGeet.kt
@@ -1,8 +1,10 @@
 package geet
 
+import geet.commands.*
+
 fun processGeet(parseData: Map<String, String>): Unit {
     when (parseData["command"]) {
-        "init" -> println("init")
+        "init" -> geetInit()
         null -> guideGeet()
         else -> println("'geet ${parseData["command"]}'은 지원하는 명령어가 아닙니다.")
     }

--- a/src/main/kotlin/geet/ProcessGeet.kt
+++ b/src/main/kotlin/geet/ProcessGeet.kt
@@ -3,7 +3,20 @@ package geet
 fun processGeet(parseData: Map<String, String>): Unit {
     when (parseData["command"]) {
         "init" -> println("init")
-        null -> println("geet 설명")
+        null -> guideGeet()
         else -> println("geet ${parseData["command"]} is not a valid command. Try init instead.")
     }
+}
+
+fun guideGeet(): Unit {
+    println("<<<Geet - Git 따라 만들면서 파악하기>>>")
+    println()
+
+    println("현재 사용 가능한 명령어 목록")
+    println("   init     현재 디렉토리에 새로운 Geet 저장소를 초기화합니다.")
+    println()
+
+    println("----------------------------------------")
+    println("깃헙 저장소 링크 - https://github.com/SongJSeop/Geet")
+    println("학습 및 개발 기록 링크 - https://abyssinian-cherry-9fc.notion.site/Geet-Git-2442af8184ee48c6ae8eb5990ff7652d")
 }

--- a/src/main/kotlin/geet/ProcessGeet.kt
+++ b/src/main/kotlin/geet/ProcessGeet.kt
@@ -1,0 +1,9 @@
+package geet
+
+fun processGeet(parseData: Map<String, String>): Unit {
+    when (parseData["command"]) {
+        "init" -> println("init")
+        null -> println("geet 설명")
+        else -> println("geet ${parseData["command"]} is not a valid command. Try init instead.")
+    }
+}

--- a/src/main/kotlin/geet/commands/GeetInit.kt
+++ b/src/main/kotlin/geet/commands/GeetInit.kt
@@ -1,0 +1,13 @@
+package geet.commands
+
+import java.io.File
+
+fun geetInit(): Unit {
+    if (File(".geet").exists()) {
+        println("이미 Geet 저장소가 초기화되어 있습니다.")
+        return
+    }
+
+    File(".geet").mkdir()
+    println("Geet 저장소를 초기화했습니다.")
+}

--- a/src/main/kotlin/geet/commands/GeetInit.kt
+++ b/src/main/kotlin/geet/commands/GeetInit.kt
@@ -9,5 +9,24 @@ fun geetInit(): Unit {
     }
 
     File(".geet").mkdir()
+    File(".geet/HEAD").writeText("ref: refs/heads/master")
+    File(".geet/config").writeText("""
+        [core]
+            repositoryformatversion = 0
+            filemode = true
+            bare = false
+            logallrefupdates = true
+            ignorecase = true
+            precomposeunicode = true
+    """.trimIndent())
+    File(".geet/description").writeText("Unnamed geet repository; edit this file 'description' to name the repository.")
+    File(".geet/hooks").mkdir()
+    File(".geet/info").mkdir()
+    File(".geet/objects").mkdir()
+    File(".geet/objects/info").mkdir()
+    File(".geet/objects/pack").mkdir()
+    File(".geet/refs").mkdir()
+    File(".geet/refs/heads").mkdir()
+    File(".geet/refs/tags").mkdir()
     println("Geet 저장소를 초기화했습니다.")
 }

--- a/src/main/kotlin/parser/ParseCommandLine.kt
+++ b/src/main/kotlin/parser/ParseCommandLine.kt
@@ -2,7 +2,6 @@ package parser
 
 fun parseCommandLine(args: Array<String>): Map<String, String> {
     if (args.isEmpty()) {
-        println("명령어와 함께 입력해주세요!")
         return mapOf()
     }
 


### PR DESCRIPTION
# 💻 구현 내용

### ProcessGeet.kt 추가

- parseCommandLine으로 파싱한 커맨드라인 데이터를 받아 Geet 명령어를 실행하는 processGeet 함수 추가
- 명령어를 입력하지 않은 경우 Geet 설명을 출력하는 guideGeet 함수 추가
- 지원하지 않는 명령어를 입력한 경우 안내 문구 출력

### GeetInit.kt 추가

- java.io.File 라이브러리로 파일시스템 사용
- .geet 폴더 생성
- git init 명령어처럼 필요한 파일 및 폴더 추가

# 🖼️ 동작 화면

<img width="637" alt="image" src="https://github.com/SongJSeop/Geet/assets/101378867/ad009d2d-3f4e-41d3-a2c5-1808780bb6db">


