### PR TITLE
log 명령어 처리 구현

### DIFF
--- a/src/main/kotlin/geet/commands/porcelain/geetLog.kt
+++ b/src/main/kotlin/geet/commands/porcelain/geetLog.kt
@@ -1,5 +1,22 @@
 package geet.commands.porcelain
 
+import geet.exceptions.BadRequest
+import geet.utils.commandutil.porcelainutil.getCommitObjectData
+import geet.utils.commandutil.porcelainutil.getCurrentRefCommitHash
+
 fun geetLog(commandLines: Array<String>): Unit {
-    println("geetLog")
+    if (commandLines.size != 1) {
+        throw BadRequest("log 명령어는 다른 옵션을 받지 않습니다.")
+    }
+
+    var commitHash = getCurrentRefCommitHash()
+    while (true) {
+        val commitObjectData = getCommitObjectData(commitHash)
+        println("commit ${commitHash}")
+        println("Date: ${commitObjectData.datetime}")
+        println()
+        println("\t${commitObjectData.message}")
+        println()
+        commitHash = commitObjectData.parent ?: break
+    }
 }

--- a/src/main/kotlin/geet/commands/porcelain/geetLog.kt
+++ b/src/main/kotlin/geet/commands/porcelain/geetLog.kt
@@ -11,12 +11,13 @@ fun geetLog(commandLines: Array<String>): Unit {
 
     var commitHash = getCurrentRefCommitHash()
     while (true) {
+        println("-------------------------------------")
         val commitObjectData = getCommitObjectData(commitHash)
-        println("commit ${commitHash}")
-        println("Date: ${commitObjectData.datetime}")
+        println("\u001B[32mcommit \u001B[0m${commitHash}")
+        if (commitObjectData.parent != null) println("\u001B[34mMerge To: \u001B[0m${commitObjectData.parent}")
+        println("\u001B[33mDate: \u001B[0m${commitObjectData.datetime}")
         println()
         println("\t${commitObjectData.message}")
-        println()
         commitHash = commitObjectData.parent ?: break
     }
 }

--- a/src/main/kotlin/geet/commands/porcelain/geetLog.kt
+++ b/src/main/kotlin/geet/commands/porcelain/geetLog.kt
@@ -1,0 +1,5 @@
+package geet.commands.porcelain
+
+fun geetLog(commandLines: Array<String>): Unit {
+    println("geetLog")
+}

--- a/src/main/kotlin/geet/commands/porcelain/geetReset.kt
+++ b/src/main/kotlin/geet/commands/porcelain/geetReset.kt
@@ -10,7 +10,7 @@ data class GeetResetOptions(
     var commitHash: String = getCurrentRefCommitHash()
 )
 
-fun geetReset(commandLines: Array<String>) {
+fun geetReset(commandLines: Array<String>): Unit {
     val geetResetOptions = getGeetResetOptions(commandLines)
     reset(geetResetOptions)
 }

--- a/src/main/kotlin/geet/processGeet.kt
+++ b/src/main/kotlin/geet/processGeet.kt
@@ -21,9 +21,10 @@ fun processGeet(commandLines: Array<String>): Unit {
     }
 
     when (commandLines[0]) {
+        "status" -> geetStatus(commandLines)
+        "log" -> geetLog(commandLines)
         "add" -> geetAdd(commandLines)
         "commit" -> geetCommit(commandLines)
-        "status" -> geetStatus(commandLines)
         "reset" -> geetReset(commandLines)
         "hash-object" -> geetHashObject(commandLines)
         "cat-file" -> geetCatFile(commandLines)
@@ -43,9 +44,10 @@ fun guideGeet(): Unit {
     println("|  help  |  사용 가능한 Geet 명령어 목록을 출력합니다.  |")
     println("<<< porcelain 명령어 >>>")
     println("|  init  |  현재 디렉토리에 새로운 Geet 저장소를 초기화합니다.  |")
+    println("|  status  |  현재 저장소의 상태를 출력합니다.  |")
+    println("|  log  |  현재 저장소의 커밋 로그를 출력합니다.  |")
     println("|  add  |  파일을 Staging Area에 추가합니다.  |")
     println("|  commit  |  Staging Area에 저장된 파일을 커밋합니다.  |")
-    println("|  status  |  현재 저장소의 상태를 출력합니다.  |")
     println("|  reset  |  옵션에 따라 Staging Area와 Working Directory를 초기화하거나, HEAD가 가리키는 커밋을 변경합니다.  |")
     println("<<< plumbing 명령어 >>>")
     println("|  hash-object  |  파일을 해시하여 Geet 저장소에 저장합니다.  |")

--- a/src/main/kotlin/geet/utils/commandutil/porcelainutil/logUtil.kt
+++ b/src/main/kotlin/geet/utils/commandutil/porcelainutil/logUtil.kt
@@ -1,6 +1,7 @@
 package geet.utils.commandutil.porcelainutil
 
 import geet.utils.GEET_OBJECTS_DIR_PATH
+import geet.utils.decompressFromZlib
 import java.io.File
 import java.time.LocalDateTime
 
@@ -15,7 +16,7 @@ fun getCommitObjectData(commitHash: String): CommitObjectData {
     val dirName = commitHash.substring(0, 2)
     val fileName = commitHash.substring(2)
     val file = File("${GEET_OBJECTS_DIR_PATH}/$dirName/$fileName")
-    val content = file.readText().trim()
+    val content = decompressFromZlib(file.readText()).trim()
 
     val splitContent = content.split("\n")
     val tree = splitContent[0].split(" ")[1]
@@ -23,7 +24,7 @@ fun getCommitObjectData(commitHash: String): CommitObjectData {
     var datetime: LocalDateTime
     var message: String
 
-    if (splitContent.size == 4) {
+    if (splitContent[3] == "") {
         parent = splitContent[1].split(" ")[1]
         datetime = LocalDateTime.parse(splitContent[2].split(" ")[1])
         message = splitContent.subList(4, splitContent.size).joinToString("\n")

--- a/src/main/kotlin/geet/utils/commandutil/porcelainutil/logUtil.kt
+++ b/src/main/kotlin/geet/utils/commandutil/porcelainutil/logUtil.kt
@@ -1,0 +1,37 @@
+package geet.utils.commandutil.porcelainutil
+
+import geet.utils.GEET_OBJECTS_DIR_PATH
+import java.io.File
+import java.time.LocalDateTime
+
+data class CommitObjectData(
+    val tree: String,
+    val parent: String?,
+    val datetime: LocalDateTime,
+    val message: String
+)
+
+fun getCommitObjectData(commitHash: String): CommitObjectData {
+    val dirName = commitHash.substring(0, 2)
+    val fileName = commitHash.substring(2)
+    val file = File("${GEET_OBJECTS_DIR_PATH}/$dirName/$fileName")
+    val content = file.readText().trim()
+
+    val splitContent = content.split("\n")
+    val tree = splitContent[0].split(" ")[1]
+    var parent: String?
+    var datetime: LocalDateTime
+    var message: String
+
+    if (splitContent.size == 4) {
+        parent = splitContent[1].split(" ")[1]
+        datetime = LocalDateTime.parse(splitContent[2].split(" ")[1])
+        message = splitContent.subList(4, splitContent.size).joinToString("\n")
+    } else {
+        parent = null
+        datetime = LocalDateTime.parse(splitContent[1].split(" ")[1])
+        message = splitContent.subList(3, splitContent.size).joinToString("\n")
+    }
+
+    return CommitObjectData(tree, parent, datetime, message)
+}


### PR DESCRIPTION
# 💻 구현 내용

- log 명령어 입력시 현재 브랜치 커밋 기준으로 부모 커밋을 따라가며 정보 출력
- 커밋 정보를 가져오는 getCommitObjectData 함수 구현

# 🖼️ 동작 화면

![image](https://github.com/SongJSeop/Geet/assets/101378867/02d1c16a-e0c0-449e-a755-46f5fb19ac31)
