### PR TITLE
add 명령어 처리 / IndexManager, ObjectManger, IgnoreManager 추가 /

### DIFF
--- a/src/main/kotlin/geet/command/geetAdd.kt
+++ b/src/main/kotlin/geet/command/geetAdd.kt
@@ -1,10 +1,7 @@
 package geet.command
 
 import geet.exception.BadRequest
-import geet.util.const.indexManager
-import geet.util.const.objectManager
-import geet.util.const.resetColor
-import geet.util.const.yellow
+import geet.util.const.*
 import geet.util.getRelativePathFromRoot
 import java.io.File
 
@@ -28,7 +25,7 @@ fun geetAdd(commandLines: Array<String>): Unit {
     }
 
     val objectInLastCommit = indexManager.searchObjectFromLastCommit(filePath)
-        ?: throw BadRequest("파일이 존재하지 않습니다.: ${yellow}${filePath}${resetColor}")
+        ?: throw BadRequest("파일이 존재하지 않습니다.: ${red}${filePath}${resetColor}")
     indexManager.addToStage(objectInLastCommit, deleted = true)
     indexManager.writeIndex()
 }

--- a/src/main/kotlin/geet/command/geetAdd.kt
+++ b/src/main/kotlin/geet/command/geetAdd.kt
@@ -34,7 +34,14 @@ fun geetAdd(commandLines: Array<String>): Unit {
 }
 
 fun addFileToStage(file: File) {
+    val filePath = getRelativePathFromRoot(file)
     val blob = objectManager.saveBlob(file)
+
+    val samePathObjectInStage = indexManager.searchObjectFromStage(filePath)
+    if (samePathObjectInStage != null) {
+        indexManager.removeFromStage(filePath)
+    }
+
     indexManager.addToStage(blob)
 }
 

--- a/src/main/kotlin/geet/command/geetAdd.kt
+++ b/src/main/kotlin/geet/command/geetAdd.kt
@@ -2,6 +2,7 @@ package geet.command
 
 import geet.exception.BadRequest
 import geet.util.const.indexManager
+import geet.util.const.objectManager
 import geet.util.const.resetColor
 import geet.util.const.yellow
 import geet.util.getRelativePathFromRoot
@@ -21,17 +22,28 @@ fun geetAdd(commandLines: Array<String>): Unit {
         } else {
             addAllFilesInDirectory(commandFile)
         }
+
+        indexManager.writeIndex()
+        return
     }
 
     val objectInLastCommit = indexManager.searchObjectFromLastCommit(filePath)
         ?: throw BadRequest("파일이 존재하지 않습니다.: ${yellow}${filePath}${resetColor}")
     indexManager.addToStage(objectInLastCommit, deleted = true)
+    indexManager.writeIndex()
 }
 
 fun addFileToStage(file: File) {
-    // TODO: 구현
+    val blob = objectManager.saveBlob(file)
+    indexManager.addToStage(blob)
 }
 
 fun addAllFilesInDirectory(directory: File) {
-    // TODO: 구현
+    directory.listFiles()?.forEach { file ->
+        if (file.isDirectory) {
+            addAllFilesInDirectory(file)
+        } else {
+            addFileToStage(file)
+        }
+    }
 }

--- a/src/main/kotlin/geet/command/geetAdd.kt
+++ b/src/main/kotlin/geet/command/geetAdd.kt
@@ -1,0 +1,5 @@
+package geet.command
+
+fun geetAdd(commandLines: Array<String>): Unit {
+    println("geetAdd")
+}

--- a/src/main/kotlin/geet/command/geetAdd.kt
+++ b/src/main/kotlin/geet/command/geetAdd.kt
@@ -1,5 +1,37 @@
 package geet.command
 
+import geet.exception.BadRequest
+import geet.util.const.indexManager
+import geet.util.const.resetColor
+import geet.util.const.yellow
+import geet.util.getRelativePathFromRoot
+import java.io.File
+
 fun geetAdd(commandLines: Array<String>): Unit {
-    println("geetAdd")
+    if (commandLines.size != 2) {
+        throw BadRequest("add 명령어에 대한 옵션이 올바르지 않습니다. ${yellow}'add <file-path>'${resetColor} 형식으로 입력해주세요.")
+    }
+
+    val commandFile = File(commandLines[1])
+    val filePath = getRelativePathFromRoot(commandFile)
+
+    if (commandFile.exists()) {
+        if (commandFile.isFile) {
+            addFileToStage(commandFile)
+        } else {
+            addAllFilesInDirectory(commandFile)
+        }
+    }
+
+    val objectInLastCommit = indexManager.searchObjectFromLastCommit(filePath)
+        ?: throw BadRequest("파일이 존재하지 않습니다.: ${yellow}${filePath}${resetColor}")
+    indexManager.addToStage(objectInLastCommit, deleted = true)
+}
+
+fun addFileToStage(file: File) {
+    // TODO: 구현
+}
+
+fun addAllFilesInDirectory(directory: File) {
+    // TODO: 구현
 }

--- a/src/main/kotlin/geet/command/geetAdd.kt
+++ b/src/main/kotlin/geet/command/geetAdd.kt
@@ -14,10 +14,11 @@ fun geetAdd(commandLines: Array<String>): Unit {
     val filePath = getRelativePathFromRoot(commandFile)
 
     if (commandFile.exists()) {
+        if (ignoreManager.isIgnored(commandFile)) {
+            throw BadRequest(".geetignore에 의해 무시되는 파일입니다.: ${red}${filePath}${resetColor}")
+        }
+
         if (commandFile.isFile) {
-            if (ignoreManager.isIgnored(commandFile)) {
-                throw BadRequest(".geetignore에 의해 무시되는 파일입니다.: ${red}${filePath}${resetColor}")
-            }
             addFileToStage(commandFile)
         } else {
             addAllFilesInDirectory(commandFile)
@@ -34,6 +35,10 @@ fun geetAdd(commandLines: Array<String>): Unit {
 }
 
 fun addFileToStage(file: File) {
+    if (ignoreManager.isIgnored(file)) {
+        return
+    }
+
     val filePath = getRelativePathFromRoot(file)
     val blob = objectManager.saveBlob(file)
 
@@ -46,6 +51,10 @@ fun addFileToStage(file: File) {
 }
 
 fun addAllFilesInDirectory(directory: File) {
+    if (ignoreManager.isIgnored(directory)) {
+        return
+    }
+
     directory.listFiles()?.forEach { file ->
         if (file.isDirectory) {
             addAllFilesInDirectory(file)

--- a/src/main/kotlin/geet/command/geetAdd.kt
+++ b/src/main/kotlin/geet/command/geetAdd.kt
@@ -15,6 +15,9 @@ fun geetAdd(commandLines: Array<String>): Unit {
 
     if (commandFile.exists()) {
         if (commandFile.isFile) {
+            if (ignoreManager.isIgnored(commandFile)) {
+                throw BadRequest(".geetignore에 의해 무시되는 파일입니다.: ${red}${filePath}${resetColor}")
+            }
             addFileToStage(commandFile)
         } else {
             addAllFilesInDirectory(commandFile)

--- a/src/main/kotlin/geet/command/geetBranch.kt
+++ b/src/main/kotlin/geet/command/geetBranch.kt
@@ -12,6 +12,10 @@ data class BranchCommandOptions(
 fun geetBranch(commandLines: Array<String>): Unit {
     val options = getBranchCommandOptions(commandLines)
 
+    if (options.branchName == null && options.delete) {
+        throw BadRequest("삭제하기 위한 브랜치 이름이 없습니다.")
+    }
+
     if (options.branchName == null) {
         printBranchList()
         return

--- a/src/main/kotlin/geet/command/geetHelp.kt
+++ b/src/main/kotlin/geet/command/geetHelp.kt
@@ -8,6 +8,7 @@ import geet.util.const.yellow
 val supportingCommandsList = mapOf<String, String>(
     "help" to "Geet에 대한 설명 및 지원하는 명령어 목록을 출력합니다.",
     "init" to "새로운 Git 저장소를 초기화합니다.",
+    "add" to "파일을 스테이징 영역에 추가합니다.",
     "branch" to "브랜치 목록을 출력하거나, 새로운 브랜치를 생성합니다.",
 )
 

--- a/src/main/kotlin/geet/enums/GeetObjectType.kt
+++ b/src/main/kotlin/geet/enums/GeetObjectType.kt
@@ -1,0 +1,7 @@
+package geet.enums
+
+enum class GeetObjectType(val value: String) {
+    BLOB("blob"),
+    TREE("tree"),
+    COMMIT("commit")
+}

--- a/src/main/kotlin/geet/enums/StageObjectStatus.kt
+++ b/src/main/kotlin/geet/enums/StageObjectStatus.kt
@@ -1,7 +1,7 @@
 package geet.enums
 
 enum class StageObjectStatus {
-    ADDED,
+    NEW,
     MODIFIED,
     DELETED,
     UNTRACKED

--- a/src/main/kotlin/geet/enums/StageObjectStatus.kt
+++ b/src/main/kotlin/geet/enums/StageObjectStatus.kt
@@ -1,0 +1,8 @@
+package geet.enums
+
+enum class StageObjectStatus {
+    ADDED,
+    MODIFIED,
+    DELETED,
+    UNTRACKED
+}

--- a/src/main/kotlin/geet/geetobject/GeetBlob.kt
+++ b/src/main/kotlin/geet/geetobject/GeetBlob.kt
@@ -1,7 +1,9 @@
 package geet.geetobject
 
 import geet.enums.GeetObjectType.BLOB
+import kotlinx.serialization.Serializable
 
+@Serializable
 class GeetBlob(
     override val content: String,
     override val filePath: String

--- a/src/main/kotlin/geet/geetobject/GeetBlob.kt
+++ b/src/main/kotlin/geet/geetobject/GeetBlob.kt
@@ -1,9 +1,11 @@
 package geet.geetobject
 
+import geet.enums.GeetObjectType.BLOB
+
 class GeetBlob(
     override val content: String,
     override val filePath: String
 ): GeetObjectWithFile {
 
-    override val type: String = "blob"
+    override val type = BLOB
 }

--- a/src/main/kotlin/geet/geetobject/GeetBlob.kt
+++ b/src/main/kotlin/geet/geetobject/GeetBlob.kt
@@ -1,0 +1,9 @@
+package geet.geetobject
+
+class GeetBlob(
+    override val content: String,
+    override val filePath: String
+): GeetObjectWithFile {
+
+    override val type: String = "blob"
+}

--- a/src/main/kotlin/geet/geetobject/GeetCommit.kt
+++ b/src/main/kotlin/geet/geetobject/GeetCommit.kt
@@ -1,0 +1,21 @@
+package geet.geetobject
+
+import java.time.LocalDateTime
+
+class GeetCommit(
+    val tree: GeetTree,
+    val parent: GeetCommit?,
+    val dateTime: LocalDateTime = LocalDateTime.now(),
+    val message: String
+): GeetObject {
+
+    override val type: String = "commit"
+    override val content: String
+        get() {
+            return "tree ${tree.hashString}\n" +
+                    (parent?.let { "parent ${it.hashString}\n" } ?: "") +
+                    "date ${dateTime.toString()}\n" +
+                    "\n" +
+                    message
+        }
+}

--- a/src/main/kotlin/geet/geetobject/GeetCommit.kt
+++ b/src/main/kotlin/geet/geetobject/GeetCommit.kt
@@ -13,8 +13,8 @@ class GeetCommit(
     override val type = COMMIT
     override val content: String
         get() {
-            return "tree ${tree.hashString}\n" +
-                    (parent?.let { "parent ${it.hashString}\n" } ?: "") +
+            return "tree ${tree.hash}\n" +
+                    (parent?.let { "parent ${it.hash}\n" } ?: "") +
                     "date ${dateTime.toString()}\n" +
                     "\n" +
                     message

--- a/src/main/kotlin/geet/geetobject/GeetCommit.kt
+++ b/src/main/kotlin/geet/geetobject/GeetCommit.kt
@@ -1,5 +1,6 @@
 package geet.geetobject
 
+import geet.enums.GeetObjectType.COMMIT
 import java.time.LocalDateTime
 
 class GeetCommit(
@@ -9,7 +10,7 @@ class GeetCommit(
     val message: String
 ): GeetObject {
 
-    override val type: String = "commit"
+    override val type = COMMIT
     override val content: String
         get() {
             return "tree ${tree.hashString}\n" +

--- a/src/main/kotlin/geet/geetobject/GeetObject.kt
+++ b/src/main/kotlin/geet/geetobject/GeetObject.kt
@@ -1,0 +1,19 @@
+package geet.geetobject
+
+import geet.util.const.messageDigest
+
+interface GeetObject {
+
+    val type: String
+    val content: String
+    val hashString: String
+        get() {
+            val header = "${type} ${content.length}\u0000"
+            val store = header + content
+
+            val hash = messageDigest.digest(store.toByteArray())
+            return hash.joinToString("") {
+                String.format("%02x", it)
+            }
+        }
+}

--- a/src/main/kotlin/geet/geetobject/GeetObject.kt
+++ b/src/main/kotlin/geet/geetobject/GeetObject.kt
@@ -7,7 +7,7 @@ interface GeetObject {
 
     val type: GeetObjectType
     val content: String
-    val hashString: String
+    val hash: String
         get() {
             val header = "${type.value} ${content.length}\u0000"
             val store = header + content

--- a/src/main/kotlin/geet/geetobject/GeetObject.kt
+++ b/src/main/kotlin/geet/geetobject/GeetObject.kt
@@ -1,14 +1,15 @@
 package geet.geetobject
 
+import geet.enums.GeetObjectType
 import geet.util.const.messageDigest
 
 interface GeetObject {
 
-    val type: String
+    val type: GeetObjectType
     val content: String
     val hashString: String
         get() {
-            val header = "${type} ${content.length}\u0000"
+            val header = "${type.value} ${content.length}\u0000"
             val store = header + content
 
             val hash = messageDigest.digest(store.toByteArray())

--- a/src/main/kotlin/geet/geetobject/GeetObjectWithFile.kt
+++ b/src/main/kotlin/geet/geetobject/GeetObjectWithFile.kt
@@ -1,0 +1,6 @@
+package geet.geetobject
+
+interface GeetObjectWithFile: GeetObject {
+
+    val filePath: String
+}

--- a/src/main/kotlin/geet/geetobject/GeetTree.kt
+++ b/src/main/kotlin/geet/geetobject/GeetTree.kt
@@ -1,7 +1,7 @@
 package geet.geetobject
 
 class GeetTree(
-    override val filePath: String = "bak",
+    override val filePath: String,
     val tree: List<GeetObjectWithFile>
 ): GeetObjectWithFile {
 

--- a/src/main/kotlin/geet/geetobject/GeetTree.kt
+++ b/src/main/kotlin/geet/geetobject/GeetTree.kt
@@ -1,11 +1,13 @@
 package geet.geetobject
 
+import geet.enums.GeetObjectType.TREE
+
 class GeetTree(
     override val filePath: String,
     val tree: List<GeetObjectWithFile>
 ): GeetObjectWithFile {
 
-    override val type: String = "tree"
+    override val type = TREE
     override val content: String
         get() = tree.joinToString("") {
             "${it.type} ${it.hashString} ${it.filePath}\n"

--- a/src/main/kotlin/geet/geetobject/GeetTree.kt
+++ b/src/main/kotlin/geet/geetobject/GeetTree.kt
@@ -1,0 +1,13 @@
+package geet.geetobject
+
+class GeetTree(
+    override val filePath: String = "bak",
+    val tree: List<GeetObjectWithFile>
+): GeetObjectWithFile {
+
+    override val type: String = "tree"
+    override val content: String
+        get() = tree.joinToString("\n") {
+            "${it.type} ${it.hashString} ${it.filePath}\u0000"
+        }
+}

--- a/src/main/kotlin/geet/geetobject/GeetTree.kt
+++ b/src/main/kotlin/geet/geetobject/GeetTree.kt
@@ -7,7 +7,7 @@ class GeetTree(
 
     override val type: String = "tree"
     override val content: String
-        get() = tree.joinToString("\n") {
-            "${it.type} ${it.hashString} ${it.filePath}\u0000"
+        get() = tree.joinToString("") {
+            "${it.type} ${it.hashString} ${it.filePath}\n"
         }
 }

--- a/src/main/kotlin/geet/geetobject/GeetTree.kt
+++ b/src/main/kotlin/geet/geetobject/GeetTree.kt
@@ -10,6 +10,6 @@ class GeetTree(
     override val type = TREE
     override val content: String
         get() = tree.joinToString("") {
-            "${it.type} ${it.hashString} ${it.filePath}\n"
+            "${it.type} ${it.hash} ${it.filePath}\n"
         }
 }

--- a/src/main/kotlin/geet/manager/BranchManager.kt
+++ b/src/main/kotlin/geet/manager/BranchManager.kt
@@ -63,6 +63,7 @@ class BranchManager {
         }
 
         headManager.setHead(branchName)
+        // TODO: 브랜치가 가리키는 커밋 상태로 복구
     }
 
     fun deleteBranch(branchName: String) {

--- a/src/main/kotlin/geet/manager/BranchManager.kt
+++ b/src/main/kotlin/geet/manager/BranchManager.kt
@@ -1,5 +1,6 @@
 package geet.manager
 
+import geet.exception.BadRequest
 import geet.exception.NotFound
 import geet.util.const.headManager
 import geet.util.const.red
@@ -39,7 +40,7 @@ class BranchManager {
 
     fun createBranch(branchName: String) {
         if (File(refsDir, "heads/$branchName").exists()) {
-            throw NotFound("이미 존재하는 브랜치입니다.: ${red}${branchName}${resetColor}")
+            throw BadRequest("이미 존재하는 브랜치입니다.: ${red}${branchName}${resetColor}")
         }
 
 

--- a/src/main/kotlin/geet/manager/IgnoreManager.kt
+++ b/src/main/kotlin/geet/manager/IgnoreManager.kt
@@ -1,0 +1,27 @@
+package geet.manager
+
+import geet.util.getRelativePathFromRoot
+import java.io.File
+
+class IgnoreManager {
+
+    val ignoreFile = File(".geetignore")
+    val ignoreSet: Set<String>
+        get() = if (ignoreFile.exists()) {
+            val ignoreSet = mutableSetOf<String>()
+            ignoreFile.readLines().forEach {
+                if (it.isNotBlank() && !it.startsWith("#")) {
+                    ignoreSet.add(getRelativePathFromRoot(File(it)))
+                }
+            }
+            ignoreSet.add(".geet")
+            ignoreSet
+        } else {
+            setOf(".geet")
+        }
+
+    fun isIgnored(file: File): Boolean {
+        val relativePath = getRelativePathFromRoot(file)
+        return ignoreSet.any { it == relativePath }
+    }
+}

--- a/src/main/kotlin/geet/manager/IndexManager.kt
+++ b/src/main/kotlin/geet/manager/IndexManager.kt
@@ -46,13 +46,21 @@ class IndexManager {
         }
 
         val stageObject = StageObject(
-            hash = blob.hashString,
+            hash = blob.hash,
             slot = slot,
             filePath = blob.filePath,
             status = status,
             lastUpdateTime = LocalDateTime.now().toString()
         )
         indexData.stageObjects.add(stageObject)
+    }
+
+    fun removeFromStage(filePath: String) {
+        indexData.stageObjects.removeIf { it.filePath == filePath }
+    }
+
+    fun searchObjectFromStage(filePath: String): StageObject? {
+        return indexData.stageObjects.find { it.filePath == filePath }
     }
 
     fun searchObjectFromLastCommit(filePath: String): GeetBlob? {

--- a/src/main/kotlin/geet/manager/IndexManager.kt
+++ b/src/main/kotlin/geet/manager/IndexManager.kt
@@ -1,12 +1,14 @@
 package geet.manager
 
 import geet.enums.StageObjectStatus
+import geet.geetobject.GeetBlob
 import geet.geetobject.GeetObjectWithFile
 import geet.util.fromZlibToString
 import geet.util.toZlib
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.io.File
+import java.time.LocalDateTime
 
 @Serializable
 data class StageObject(
@@ -34,6 +36,10 @@ class IndexManager {
 
             return Json.decodeFromString(IndexData.serializer(), indexFile.readText().fromZlibToString())
         }
+
+    fun isInLastCommit(filePath: String): Boolean {
+        return indexData.lastCommitObjects.any { it.filePath == filePath }
+    }
 
     fun writeIndex() {
         indexFile.writeText(Json.encodeToString(IndexData.serializer(), indexData).toZlib())

--- a/src/main/kotlin/geet/manager/IndexManager.kt
+++ b/src/main/kotlin/geet/manager/IndexManager.kt
@@ -1,20 +1,19 @@
 package geet.manager
 
-import geet.geetobject.GeetBlob
+import geet.enums.StageObjectStatus
 import geet.geetobject.GeetObjectWithFile
 import geet.util.fromZlibToString
 import geet.util.toZlib
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.io.File
-import java.time.LocalDateTime
 
 @Serializable
 data class StageObject(
     val hash: String,
     val slot: Int = 0,
     val filePath: String,
-    val status: String,
+    val status: StageObjectStatus,
     val lastUpdateTime: String
 )
 

--- a/src/main/kotlin/geet/manager/IndexManager.kt
+++ b/src/main/kotlin/geet/manager/IndexManager.kt
@@ -1,0 +1,42 @@
+package geet.manager
+
+import geet.geetobject.GeetBlob
+import geet.geetobject.GeetObjectWithFile
+import geet.util.fromZlibToString
+import geet.util.toZlib
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.time.LocalDateTime
+
+@Serializable
+data class StageObject(
+    val hash: String,
+    val slot: Int = 0,
+    val filePath: String,
+    val status: String,
+    val lastUpdateTime: String
+)
+
+@Serializable
+data class IndexData(
+    val stageObjects: MutableList<StageObject>,
+    val lastCommitObjects: List<GeetObjectWithFile>
+)
+
+class IndexManager {
+
+    val indexFile = File(".geet/index")
+    val indexData: IndexData
+        get() {
+            if (!indexFile.exists()) {
+                return IndexData(stageObjects = mutableListOf(), lastCommitObjects = emptyList())
+            }
+
+            return Json.decodeFromString(IndexData.serializer(), indexFile.readText().fromZlibToString())
+        }
+
+    fun writeIndex() {
+        indexFile.writeText(Json.encodeToString(IndexData.serializer(), indexData).toZlib())
+    }
+}

--- a/src/main/kotlin/geet/manager/IndexManager.kt
+++ b/src/main/kotlin/geet/manager/IndexManager.kt
@@ -2,7 +2,6 @@ package geet.manager
 
 import geet.enums.StageObjectStatus
 import geet.geetobject.GeetBlob
-import geet.geetobject.GeetObjectWithFile
 import geet.util.fromZlibToString
 import geet.util.toZlib
 import kotlinx.serialization.Serializable
@@ -22,7 +21,7 @@ data class StageObject(
 @Serializable
 data class IndexData(
     val stageObjects: MutableList<StageObject>,
-    val lastCommitObjects: List<GeetObjectWithFile>
+    val lastCommitObjects: List<GeetBlob>
 )
 
 class IndexManager {
@@ -41,8 +40,8 @@ class IndexManager {
         var status: StageObjectStatus
         when (true) {
             deleted -> status = StageObjectStatus.DELETED
-            isInLastCommit(blob.filePath) -> status = StageObjectStatus.MODIFIED
-            else -> status = StageObjectStatus.NEW
+            (searchObjectFromLastCommit(blob.filePath) == null) -> status = StageObjectStatus.NEW
+            else -> status = StageObjectStatus.MODIFIED
         }
 
         val stageObject = StageObject(
@@ -55,8 +54,8 @@ class IndexManager {
         indexData.stageObjects.add(stageObject)
     }
 
-    fun isInLastCommit(filePath: String): Boolean {
-        return indexData.lastCommitObjects.any { it.filePath == filePath }
+    fun searchObjectFromLastCommit(filePath: String): GeetBlob? {
+        return indexData.lastCommitObjects.find { it.filePath == filePath }
     }
 
     fun writeIndex() {

--- a/src/main/kotlin/geet/manager/IndexManager.kt
+++ b/src/main/kotlin/geet/manager/IndexManager.kt
@@ -28,13 +28,14 @@ class IndexManager {
 
     val indexFile = File(".geet/index")
     val indexData: IndexData
-        get() {
-            if (!indexFile.exists()) {
-                return IndexData(stageObjects = mutableListOf(), lastCommitObjects = emptyList())
-            }
 
-            return Json.decodeFromString(IndexData.serializer(), indexFile.readText().fromZlibToString())
+    init {
+        if (indexFile.exists()) {
+            indexData = Json.decodeFromString(IndexData.serializer(), indexFile.readText().fromZlibToString())
+        } else {
+            indexData = IndexData(mutableListOf(), listOf())
         }
+    }
 
     fun addToStage(blob: GeetBlob, deleted: Boolean = false, slot: Int = 0) {
         var status: StageObjectStatus

--- a/src/main/kotlin/geet/manager/ObjectManager.kt
+++ b/src/main/kotlin/geet/manager/ObjectManager.kt
@@ -14,8 +14,8 @@ class ObjectManager {
     fun saveBlob(file: File): GeetBlob {
         val blob = GeetBlob(content = file.readText(), filePath = getRelativePathFromRoot(file))
         
-        val blobDir = File(objectDir, blob.hashString.substring(0, 2))
-        val blobFile = File(blobDir, blob.hashString.substring(2))
+        val blobDir = File(objectDir, blob.hash.substring(0, 2))
+        val blobFile = File(blobDir, blob.hash.substring(2))
 
         if (!blobDir.exists()) {
             blobDir.mkdirs()
@@ -37,8 +37,8 @@ class ObjectManager {
 
         val treeObject = GeetTree(filePath = getRelativePathFromRoot(file), tree = tree)
 
-        val treeDir = File(objectDir, treeObject.hashString.substring(0, 2))
-        val treeFile = File(treeDir, treeObject.hashString.substring(2))
+        val treeDir = File(objectDir, treeObject.hash.substring(0, 2))
+        val treeFile = File(treeDir, treeObject.hash.substring(2))
 
         if (!treeDir.exists()) {
             treeDir.mkdirs()

--- a/src/main/kotlin/geet/manager/ObjectManager.kt
+++ b/src/main/kotlin/geet/manager/ObjectManager.kt
@@ -1,0 +1,34 @@
+package geet.manager
+
+import geet.exception.BadRequest
+import geet.exception.NotFound
+import geet.geetobject.GeetBlob
+import geet.util.toZlib
+import java.io.File
+
+class ObjectManager {
+    
+    val objectDir = File(".geet/objects")
+    
+    fun saveBlob(file: File): String {
+        if (!file.exists()) {
+            throw NotFound("파일이 존재하지 않습니다.")
+        }
+
+        if (file.isDirectory) {
+            throw BadRequest("디렉토리를 Blob개체로 생성할 수 없습니다.")
+        }
+
+        val blob = GeetBlob(content = file.readText(), filePath = file.name)
+        
+        val blobDir = File(objectDir, blob.hashString.substring(0, 2))
+        val blobFile = File(blobDir, blob.hashString.substring(2))
+
+        if (!blobDir.exists()) {
+            blobDir.mkdirs()
+        }
+
+        blobFile.writeText(blob.content.toZlib())
+        return blob.hashString
+    }
+}

--- a/src/main/kotlin/geet/manager/ObjectManager.kt
+++ b/src/main/kotlin/geet/manager/ObjectManager.kt
@@ -3,6 +3,8 @@ package geet.manager
 import geet.exception.BadRequest
 import geet.exception.NotFound
 import geet.geetobject.GeetBlob
+import geet.geetobject.GeetObjectWithFile
+import geet.geetobject.GeetTree
 import geet.util.toZlib
 import java.io.File
 
@@ -10,15 +12,7 @@ class ObjectManager {
     
     val objectDir = File(".geet/objects")
     
-    fun saveBlob(file: File): String {
-        if (!file.exists()) {
-            throw NotFound("파일이 존재하지 않습니다.")
-        }
-
-        if (file.isDirectory) {
-            throw BadRequest("디렉토리를 Blob개체로 생성할 수 없습니다.")
-        }
-
+    fun saveBlob(file: File): GeetBlob {
         val blob = GeetBlob(content = file.readText(), filePath = file.name)
         
         val blobDir = File(objectDir, blob.hashString.substring(0, 2))
@@ -29,6 +23,29 @@ class ObjectManager {
         }
 
         blobFile.writeText(blob.content.toZlib())
-        return blob.hashString
+        return blob
+    }
+
+    fun saveTree(file: File): GeetTree {
+        val tree = mutableListOf<GeetObjectWithFile>()
+        file.listFiles()?.forEach { it ->
+            if (it.isDirectory) {
+                tree.add(saveTree(it))
+            } else {
+                tree.add(saveBlob(it))
+            }
+        }
+
+        val treeObject = GeetTree(filePath = file.path, tree = tree)
+
+        val treeDir = File(objectDir, treeObject.hashString.substring(0, 2))
+        val treeFile = File(treeDir, treeObject.hashString.substring(2))
+
+        if (!treeDir.exists()) {
+            treeDir.mkdirs()
+        }
+
+        treeFile.writeText(treeObject.content.toZlib())
+        return treeObject
     }
 }

--- a/src/main/kotlin/geet/manager/ObjectManager.kt
+++ b/src/main/kotlin/geet/manager/ObjectManager.kt
@@ -1,10 +1,9 @@
 package geet.manager
 
-import geet.exception.BadRequest
-import geet.exception.NotFound
 import geet.geetobject.GeetBlob
 import geet.geetobject.GeetObjectWithFile
 import geet.geetobject.GeetTree
+import geet.util.getRelativePathFromRoot
 import geet.util.toZlib
 import java.io.File
 
@@ -13,7 +12,7 @@ class ObjectManager {
     val objectDir = File(".geet/objects")
     
     fun saveBlob(file: File): GeetBlob {
-        val blob = GeetBlob(content = file.readText(), filePath = file.name)
+        val blob = GeetBlob(content = file.readText(), filePath = getRelativePathFromRoot(file))
         
         val blobDir = File(objectDir, blob.hashString.substring(0, 2))
         val blobFile = File(blobDir, blob.hashString.substring(2))
@@ -29,14 +28,14 @@ class ObjectManager {
     fun saveTree(file: File): GeetTree {
         val tree = mutableListOf<GeetObjectWithFile>()
         file.listFiles()?.forEach { it ->
-            if (it.isDirectory) {
+            if (it.isDirectory && !it.listFiles().isNullOrEmpty()) {
                 tree.add(saveTree(it))
             } else {
                 tree.add(saveBlob(it))
             }
         }
 
-        val treeObject = GeetTree(filePath = file.path, tree = tree)
+        val treeObject = GeetTree(filePath = getRelativePathFromRoot(file), tree = tree)
 
         val treeDir = File(objectDir, treeObject.hashString.substring(0, 2))
         val treeFile = File(treeDir, treeObject.hashString.substring(2))

--- a/src/main/kotlin/geet/processGeet.kt
+++ b/src/main/kotlin/geet/processGeet.kt
@@ -18,6 +18,7 @@ fun processGeet(commandLines: Array<String>): Unit {
 
     when (commandLines[0]) {
         "init" -> geetInit(commandLines)
+        "add" -> geetAdd(commandLines)
         "branch" -> geetBranch(commandLines)
         else -> throw BadRequest("지원하지 않는 명령어입니다.: ${red}${commandLines[0]}${resetColor}")
     }

--- a/src/main/kotlin/geet/util/const/geetConst.kt
+++ b/src/main/kotlin/geet/util/const/geetConst.kt
@@ -1,0 +1,5 @@
+package geet.util.const
+
+import java.security.MessageDigest
+
+val messageDigest: MessageDigest = MessageDigest.getInstance("SHA-1")

--- a/src/main/kotlin/geet/util/const/manager.kt
+++ b/src/main/kotlin/geet/util/const/manager.kt
@@ -2,6 +2,10 @@ package geet.util.const
 
 import geet.manager.BranchManager
 import geet.manager.HeadManager
+import geet.manager.IgnoreManager
+import geet.manager.ObjectManager
 
 val headManager = HeadManager()
 val branchManager = BranchManager()
+val ignoreManager = IgnoreManager()
+val objectManager = ObjectManager()

--- a/src/main/kotlin/geet/util/const/manager.kt
+++ b/src/main/kotlin/geet/util/const/manager.kt
@@ -1,11 +1,9 @@
 package geet.util.const
 
-import geet.manager.BranchManager
-import geet.manager.HeadManager
-import geet.manager.IgnoreManager
-import geet.manager.ObjectManager
+import geet.manager.*
 
 val headManager = HeadManager()
 val branchManager = BranchManager()
 val ignoreManager = IgnoreManager()
 val objectManager = ObjectManager()
+val indexManager = IndexManager()

--- a/src/main/kotlin/geet/util/geetUtil.kt
+++ b/src/main/kotlin/geet/util/geetUtil.kt
@@ -1,6 +1,13 @@
 package geet.util
 
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.util.*
+import java.util.zip.Deflater
+import java.util.zip.DeflaterOutputStream
+import java.util.zip.Inflater
+import java.util.zip.InflaterInputStream
 
 fun isGeetDirectory(): Boolean {
     val geetDir = File(".geet")
@@ -8,4 +15,32 @@ fun isGeetDirectory(): Boolean {
     val geetRefsDir = File(geetDir, "refs")
     val geetHeadFile = File(geetDir, "HEAD")
     return geetDir.exists() && geetObjectDir.exists() && geetRefsDir.exists() && geetHeadFile.exists()
+}
+
+fun String.toZlib(): String {
+    val inputData = this.toByteArray()
+    val outputStream = ByteArrayOutputStream()
+    val deflater = Deflater()
+    val deflaterOutputStream = DeflaterOutputStream(outputStream, deflater)
+
+    deflaterOutputStream.write(inputData)
+    deflaterOutputStream.close()
+
+    return Base64.getEncoder().encodeToString(outputStream.toByteArray())
+}
+
+fun String.fromZlibToString(): String {
+    val decodedByteArray = Base64.getDecoder().decode(this)
+    val inputStream = ByteArrayInputStream(decodedByteArray)
+    val inflater = Inflater()
+    val inflaterInputStream = InflaterInputStream(inputStream, inflater)
+    val outputStream = ByteArrayOutputStream()
+
+    val buffer = ByteArray(1024)
+    var length: Int
+    while (inflaterInputStream.read(buffer).also { length = it } > 0) {
+        outputStream.write(buffer, 0, length)
+    }
+
+    return outputStream.toString()
 }

--- a/src/main/kotlin/geet/util/geetUtil.kt
+++ b/src/main/kotlin/geet/util/geetUtil.kt
@@ -44,3 +44,12 @@ fun String.fromZlibToString(): String {
 
     return outputStream.toString()
 }
+
+fun getRelativePathFromRoot(file: File): String {
+    val rootPath = File(".").canonicalPath
+    val filePath = file.canonicalPath
+
+    val relativePath = filePath.removePrefix(rootPath).trimStart(File.separatorChar)
+
+    return if (relativePath.isEmpty()) "." else relativePath
+}


### PR DESCRIPTION
# 💻 구현 내용

- add 명령어 처리
- index 파일및 스테이지를 관리하는 IndexManager 추가
- blob, tree 등 object 폴더의 개체들을 관리하는 ObjectManager 추가
- .geetignore로 무시되는 파일들을 관리하는 IgnoreManager 추가

# 🖼️ 동작 화면

<img width="615" alt="image" src="https://github.com/SongJSeop/Geet/assets/101378867/8a257f49-fc67-4962-af7e-57b572e568e0">

위는 저장되는 모습을 보기 위해 zlib 압축을 구현을 잠시 해제한 모습, 사실 index 파일 내용은 zlib으로 압축되어 저장됨
Json serializer를 이용해 index 데이터를 나타내는 data class 인스턴스를 Json 문자열로 변환하고, 그를 zlib으로 압축하여 내용으로 저장